### PR TITLE
Add --sync-calendar flag to CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea/
+env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,6 +1669,7 @@ dependencies = [
  "lambda_runtime",
  "log",
  "reqwest",
+ "rustls 0.23.36",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ jluszcz_rust_utils = { git = "https://github.com//jluszcz/rust-utils" }
 lambda_runtime = "1.*"
 log = "0.4"
 reqwest = { version = "0.13", features = ["gzip", "json", "query"] }
+rustls = { version = "0.23", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.*"
 tokio = { version = "1.*", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub async fn alerts(use_cache: bool) -> Result<Alerts> {
     ));
 
     let response = try_cached_query(use_cache, &cache_path, query_subway_alerts).await?;
-    debug!("{response}");
+    trace!("{response}");
 
     let alerts: Alerts = serde_json::from_str(&response)?;
 


### PR DESCRIPTION
- Add -s/--sync-calendar flag that syncs alerts to Google Calendar using the same CalendarClient and env vars as the Lambda
- Skip printing alerts to stdout when syncing
- Fix event_times to ensure start/end are always the same type (dateTime/dateTime or date/date); mixed types cause a 400 from Google Calendar API for open-ended alerts with no end time
- Install rustls aws-lc-rs crypto provider explicitly to resolve ambiguity when both aws-lc-rs and ring are in the dependency tree
- Add export to env file so sourcing it propagates vars to subprocesses
- Improve sync debug logs to include line name and effect