### PR TITLE
Install rustls CryptoProvider in lambda binary

### DIFF
--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -6,6 +6,7 @@ use serde_json::{Value, json};
 
 #[tokio::main]
 async fn main() -> Result<(), lambda_runtime::Error> {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     lambda::init(APP_NAME, module_path!(), false).await?;
     let func = service_fn(handler);
     lambda_runtime::run(func).await?;


### PR DESCRIPTION
Both reqwest (aws-lc-rs) and gcp_auth (ring) transitively enable competing rustls crypto backends. With both compiled in, rustls 0.23 requires an explicit install_default() call rather than auto-selecting.

main.rs already had this fix; apply the same pattern to lambda.rs.