### PR TITLE
Improve calendar event titles and run Lambda every 3 hours

### DIFF
--- a/mbtalerts.tf
+++ b/mbtalerts.tf
@@ -23,10 +23,10 @@ data "aws_s3_bucket" "code_bucket" {
   bucket = var.code_bucket
 }
 
-// Run daily at 15:00 UTC
+// Run every 3 hours
 resource "aws_cloudwatch_event_rule" "schedule" {
   name                = "mbtalerts-schedule"
-  schedule_expression = "cron(0 15 * * ? *)"
+  schedule_expression = "rate(3 hours)"
 }
 
 resource "aws_cloudwatch_event_target" "schedule_target" {


### PR DESCRIPTION
Replace brief_content truncation with effect_label + cause_phrase so wide-area alerts like "Due to severe weather..." produce titles such as "[MBTA] Service change due to severe weather" instead of the truncated "[MBTA] Due to severe weather, Subway, Bus".

Also update the Lambda schedule from daily at 15:00 UTC to every 3 hours.