### PR TITLE
Add rich event descriptions and filter PARKING_ISSUE alerts

### DIFF
--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -305,6 +305,10 @@ fn event_summary(alert: &Alert) -> String {
     format!("[{}] {}", line, label)
 }
 
+/// Builds the calendar event description from available alert fields.
+///
+/// Always includes the alert header. Appends the full description and URL
+/// on separate sections when present.
 fn event_description(alert: &Alert) -> String {
     let mut parts = vec![alert.attributes.header.trim().to_owned()];
     if let Some(desc) = &alert.attributes.description {

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -162,7 +162,12 @@ impl CalendarClient {
     }
 }
 
-const STATION_EFFECTS_TO_SKIP: &[&str] = &["STATION_ISSUE", "STOP_CLOSURE", "STATION_CLOSURE"];
+const STATION_EFFECTS_TO_SKIP: &[&str] = &[
+    "STATION_ISSUE",
+    "STOP_CLOSURE",
+    "STATION_CLOSURE",
+    "PARKING_ISSUE",
+];
 
 pub async fn sync_alerts(alerts: &Alerts, cal: &CalendarClient) -> Result<()> {
     let existing = cal.list_alert_events().await?;
@@ -241,60 +246,6 @@ fn strip_line_prefix(header: &str) -> &str {
     header.trim_start()
 }
 
-const LOCATION_STOP_MARKERS: &[&str] = &[
-    ", ",
-    " will ",
-    " this ",
-    " that ",
-    " from ",
-    " to allow",
-    " in order",
-    " starting",
-    " during",
-];
-
-/// Extract a location phrase ("between A and B" or "from A through B") from stripped content.
-fn location_phrase(content: &str) -> Option<String> {
-    let fragment = if let Some(idx) = content.find(" between ") {
-        &content[idx + 1..] // "between A and B..."
-    } else if let Some(idx) = content.find(" from ") {
-        let candidate = &content[idx + 1..]; // "from A through B..."
-        if !candidate.contains(" through ") {
-            return None;
-        }
-        candidate
-    } else {
-        return None;
-    };
-
-    let end = LOCATION_STOP_MARKERS
-        .iter()
-        .filter_map(|m| fragment.find(m))
-        .min()
-        .unwrap_or(fragment.len());
-
-    let phrase = fragment[..end].trim_end_matches(['.', ',', ' ']);
-    if phrase.is_empty() {
-        None
-    } else {
-        Some(phrase.to_string())
-    }
-}
-
-/// Extract a cause phrase ("due to X") from content, lowercased.
-fn cause_phrase(content: &str) -> Option<String> {
-    let lower = content.to_lowercase();
-    let idx = lower.find("due to")?;
-    let fragment = &lower[idx..];
-    let end = fragment.find([',', '.']).unwrap_or(fragment.len());
-    let phrase = fragment[..end].trim_end_matches(['.', ',', ' ']);
-    if phrase.is_empty() {
-        None
-    } else {
-        Some(phrase.to_string())
-    }
-}
-
 fn effect_label(effect: &str) -> &str {
     match effect {
         "SHUTTLE" => "Shuttle",
@@ -337,20 +288,25 @@ fn delay_duration_phrase(content: &str) -> Option<String> {
 
 fn event_summary(alert: &Alert) -> String {
     let line = crate::line_name(alert);
-    let content = strip_line_prefix(&alert.attributes.header);
     let label = effect_label(&alert.attributes.effect);
-    if alert.attributes.effect == "DELAY"
-        && let Some(duration) = delay_duration_phrase(content)
-    {
-        return format!("[{}] Delays of {}", line, duration);
+    if alert.attributes.effect == "DELAY" {
+        let content = strip_line_prefix(&alert.attributes.header);
+        if let Some(duration) = delay_duration_phrase(content) {
+            return format!("[{}] Delay {}", line, duration);
+        }
     }
-    if let Some(loc) = location_phrase(content) {
-        format!("[{}] {} {}", line, label, loc)
-    } else if let Some(cause) = cause_phrase(content) {
-        format!("[{}] {} {}", line, label, cause)
-    } else {
-        format!("[{}] {}", line, label)
+    format!("[{}] {}", line, label)
+}
+
+fn event_description(alert: &Alert) -> String {
+    let mut parts = vec![alert.attributes.header.trim().to_owned()];
+    if let Some(desc) = &alert.attributes.description {
+        parts.push(desc.trim().to_owned());
     }
+    if let Some(url) = &alert.attributes.url {
+        parts.push(url.clone());
+    }
+    parts.join("\n\n")
 }
 
 fn event_body(alert: &Alert) -> Value {
@@ -362,7 +318,7 @@ fn event_body(alert: &Alert) -> Value {
 
     json!({
         "summary": event_summary(alert),
-        "description": alert.attributes.description,
+        "description": event_description(alert),
         "start": start,
         "end": end,
         "transparency": "transparent",
@@ -386,6 +342,7 @@ mod test {
             attributes: AlertAttributes {
                 header: "Test header".to_owned(),
                 description: Some("Test description".to_owned()),
+                url: None,
                 active_period: vec![ActivePeriod {
                     start: start.map(str::to_owned),
                     end: end.map(str::to_owned),
@@ -404,6 +361,7 @@ mod test {
             attributes: AlertAttributes {
                 header: "Test header".to_owned(),
                 description: None,
+                url: None,
                 active_period: vec![],
                 effect: effect.to_owned(),
                 informed_entity: vec![InformedEntity {
@@ -501,7 +459,7 @@ mod test {
         );
         alert.attributes.header = "Red Line Braintree Branch: Delays of about 20 minutes due to a signal problem at Braintree.".to_owned();
         let body = event_body(&alert);
-        assert_eq!(body["summary"], "[Red Line] Delays of ~20 minutes");
+        assert_eq!(body["summary"], "[Red Line] Delay ~20 minutes");
     }
 
     #[test]
@@ -514,7 +472,7 @@ mod test {
         );
         alert.attributes.header = "Blue Line: Delays of up to 20 minutes due to signal problem near Wonderland. Trains may stand by at stations.".to_owned();
         let body = event_body(&alert);
-        assert_eq!(body["summary"], "[Blue Line] Delays of ~20 minutes");
+        assert_eq!(body["summary"], "[Blue Line] Delay ~20 minutes");
     }
 
     #[test]
@@ -539,10 +497,7 @@ mod test {
         );
         alert.attributes.header = "Due to severe weather, Subway, Bus, and Commuter Rail are operating on a reduced schedule. Ferry service is canceled.".to_owned();
         let body = event_body(&alert);
-        assert_eq!(
-            body["summary"],
-            "[MBTA] Service change due to severe weather"
-        );
+        assert_eq!(body["summary"], "[MBTA] Service change");
     }
 
     #[test]
@@ -555,10 +510,7 @@ mod test {
         );
         alert.attributes.header = "Red Line: Shuttle buses will replace service between Broadway and Ashmont this weekend.".to_owned();
         let body = event_body(&alert);
-        assert_eq!(
-            body["summary"],
-            "[Red Line] Shuttle between Broadway and Ashmont"
-        );
+        assert_eq!(body["summary"], "[Red Line] Shuttle");
     }
 
     #[test]
@@ -571,103 +523,55 @@ mod test {
         );
         alert.attributes.header = "Red Line Ashmont Branch: Service between JFK/UMass and Ashmont will operate with two shuttle trains from April 10 - 30 to allow for critical track work.".to_owned();
         let body = event_body(&alert);
-        assert_eq!(
-            body["summary"],
-            "[Red Line] Service change between JFK/UMass and Ashmont"
-        );
+        assert_eq!(body["summary"], "[Red Line] Service change");
     }
 
-    // --- location_phrase ---
+    // --- event_description ---
 
     #[test]
-    fn test_location_phrase_between_truncates_at_this() {
-        assert_eq!(
-            location_phrase(
-                "Shuttle buses will replace service between Broadway and Ashmont this weekend."
-            ),
-            Some("between Broadway and Ashmont".to_string())
-        );
+    fn test_event_description_header_only() {
+        let mut alert = make_alert("Red", "DELAY", None, None);
+        alert.attributes.description = None;
+        assert_eq!(event_description(&alert), "Test header");
     }
 
     #[test]
-    fn test_location_phrase_between_truncates_at_comma() {
-        assert_eq!(
-            location_phrase(
-                "Shuttle buses will replace service between JFK/UMass and Braintree, the weekend of Mar 29 - 30."
-            ),
-            Some("between JFK/UMass and Braintree".to_string())
-        );
+    fn test_event_description_header_and_description() {
+        let alert = make_alert("Red", "DELAY", None, None);
+        // make_alert sets description = Some("Test description")
+        assert_eq!(event_description(&alert), "Test header\n\nTest description");
     }
 
     #[test]
-    fn test_location_phrase_between_truncates_at_will() {
+    fn test_event_description_header_and_url() {
+        let mut alert = make_alert("Red", "DELAY", None, None);
+        alert.attributes.description = None;
+        alert.attributes.url = Some("https://mbta.com/RedLine".to_owned());
         assert_eq!(
-            location_phrase(
-                "Service between JFK/UMass and Ashmont will operate with two shuttle trains."
-            ),
-            Some("between JFK/UMass and Ashmont".to_string())
+            event_description(&alert),
+            "Test header\n\nhttps://mbta.com/RedLine"
         );
     }
 
     #[test]
-    fn test_location_phrase_from_through() {
+    fn test_event_description_all_fields() {
+        let mut alert = make_alert("Red", "SHUTTLE", None, None);
+        alert.attributes.url = Some("https://mbta.com/RedLine".to_owned());
         assert_eq!(
-            location_phrase(
-                "Shuttle buses replace service from JFK/UMass through Ashmont (and Mattapan), April 1 - 9."
-            ),
-            Some("from JFK/UMass through Ashmont (and Mattapan)".to_string())
+            event_description(&alert),
+            "Test header\n\nTest description\n\nhttps://mbta.com/RedLine"
         );
     }
 
     #[test]
-    fn test_location_phrase_between_truncates_at_from_date() {
+    fn test_event_description_trims_whitespace() {
+        let mut alert = make_alert("Red", "DELAY", None, None);
+        alert.attributes.header = "  Header with spaces  ".to_owned();
+        alert.attributes.description = Some("  Description with spaces  ".to_owned());
         assert_eq!(
-            location_phrase(
-                "Shuttle buses replace service between Back Bay and Forest Hills from February 28 - March 8 to allow for track work."
-            ),
-            Some("between Back Bay and Forest Hills".to_string())
+            event_description(&alert),
+            "Header with spaces\n\nDescription with spaces"
         );
-    }
-
-    #[test]
-    fn test_location_phrase_from_to_without_through_returns_none() {
-        assert_eq!(
-            location_phrase("Shuttle buses replace service from North Station to Anderson/Woburn."),
-            None
-        );
-    }
-
-    #[test]
-    fn test_location_phrase_none_when_no_pattern() {
-        assert_eq!(
-            location_phrase("Service will originate / terminate at the Lake Street platform."),
-            None
-        );
-    }
-
-    // --- cause_phrase ---
-
-    #[test]
-    fn test_cause_phrase_due_to_at_start() {
-        assert_eq!(
-            cause_phrase(
-                "Due to severe weather, Subway, Bus, and Commuter Rail are operating on a reduced schedule."
-            ),
-            Some("due to severe weather".to_string())
-        );
-    }
-
-    #[test]
-    fn test_cause_phrase_due_to_midsentence() {
-        assert_eq!(
-            cause_phrase("Delays expected on the Orange Line due to an earlier incident."),
-            Some("due to an earlier incident".to_string())
-        );
-    }
-
-    #[test]
-    fn test_cause_phrase_none_when_absent() {
-        assert_eq!(cause_phrase("Test header"), None);
     }
 
     // --- effect_label ---
@@ -710,6 +614,11 @@ mod test {
     }
 
     #[test]
+    fn test_parking_issue_is_skipped() {
+        assert!(STATION_EFFECTS_TO_SKIP.contains(&"PARKING_ISSUE"));
+    }
+
+    #[test]
     fn test_shuttle_is_not_skipped() {
         assert!(!STATION_EFFECTS_TO_SKIP.contains(&"SHUTTLE"));
     }
@@ -723,7 +632,7 @@ mod test {
             Some("2024-06-01T23:00:00-04:00"),
         );
         let body = event_body(&alert);
-        assert_eq!(body["description"], "Test description");
+        assert_eq!(body["description"], "Test header\n\nTest description");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use jluszcz_rust_utils::cache::{dated_cache_path, try_cached_query};
-use log::trace;
+use log::{trace, warn};
 
 use crate::mbta::query_subway_alerts;
 use crate::types::{Alert, Alerts};
@@ -19,7 +19,10 @@ pub fn line_name(alert: &Alert) -> &str {
                 "Orange" => "Orange Line",
                 "Blue" => "Blue Line",
                 r if r.starts_with("Green") => "Green Line",
-                _ => "MBTA",
+                r => {
+                    warn!("Unknown route '{r}', falling back to MBTA");
+                    "MBTA"
+                }
             };
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ mod test {
             attributes: types::AlertAttributes {
                 header: "Test header".to_owned(),
                 description: None,
+                url: None,
                 active_period: vec![],
                 effect: "DELAY".to_owned(),
                 informed_entity: vec![types::InformedEntity {
@@ -64,6 +65,7 @@ mod test {
             attributes: types::AlertAttributes {
                 header: "Test header".to_owned(),
                 description: None,
+                url: None,
                 active_period: vec![],
                 effect: "DELAY".to_owned(),
                 informed_entity: vec![],
@@ -77,6 +79,7 @@ mod test {
             attributes: types::AlertAttributes {
                 header: "Test header".to_owned(),
                 description: None,
+                url: None,
                 active_period: vec![],
                 effect: "DELAY".to_owned(),
                 informed_entity: vec![types::InformedEntity { route: None }],

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,7 @@ mod test {
             attributes: AlertAttributes {
                 header: "Service disruption in effect".to_owned(),
                 description: None,
+                url: None,
                 active_period: vec![ActivePeriod {
                     start: start.map(str::to_owned),
                     end: end.map(str::to_owned),
@@ -193,6 +194,7 @@ mod test {
             attributes: AlertAttributes {
                 header: "Some header".to_owned(),
                 description: None,
+                url: None,
                 active_period: vec![],
                 effect: "SUSPENSION".to_owned(),
                 informed_entity: vec![InformedEntity {

--- a/src/mbta.rs
+++ b/src/mbta.rs
@@ -1,13 +1,17 @@
 use jluszcz_rust_utils::query::http_get;
+use log::{debug, info};
 
 const API_URL: &str = "https://api-v3.mbta.com";
 const ALERTS: &str = "alerts";
 const ROUTES: &str = "Red,Orange,Blue,Green-B,Green-C,Green-D,Green-E";
 
 pub async fn query_subway_alerts() -> anyhow::Result<String> {
-    http_get(
+    debug!("Fetching MBTA subway alerts");
+    let response = http_get(
         &format!("{}/{}", API_URL, ALERTS),
         &[("filter[route]", ROUTES)],
     )
-    .await
+    .await?;
+    info!("Fetched MBTA subway alerts");
+    Ok(response)
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,6 +15,7 @@ pub struct Alert {
 pub struct AlertAttributes {
     pub header: String,
     pub description: Option<String>,
+    pub url: Option<String>,
     pub active_period: Vec<ActivePeriod>,
     pub effect: String,
     pub informed_entity: Vec<InformedEntity>,


### PR DESCRIPTION
Calendar events now include a full description built from the alert header, optional description text, and URL (when present). Event titles are simplified to [Line] EffectLabel (with delay duration when available), moving detail into the description instead.

Also filters PARKING_ISSUE alerts from the calendar alongside the existing station-level effect exclusions.