### PR TITLE
Improve alert title formatting and refactor duplicate logic

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -31,3 +31,13 @@ pub struct ActivePeriod {
 pub struct InformedEntity {
     pub route: Option<String>,
 }
+
+impl Alert {
+    pub fn period_start(&self) -> Option<&str> {
+        self.attributes.active_period.first()?.start.as_deref()
+    }
+
+    pub fn period_end(&self) -> Option<&str> {
+        self.attributes.active_period.first()?.end.as_deref()
+    }
+}


### PR DESCRIPTION
- Use first sentence of header as title fallback for all effects (not just unmapped), so e.g. SERVICE_CHANGE with no location shows the actual alert text instead of the generic label
- Strip first sentence from body line consistently whenever it appears in the title (was previously only done for unmapped effects)
- Add Alert::period_start()/period_end() methods to eliminate duplicated active_period extraction in event_body and format_alert
- Restructure event_summary to a single first_sentence fallback path
- Add uses_first_sentence_summary() helper that mirrors event_summary logic
- Update main.rs output format: bold line prefix, date range, effect + body
- Fix "due to" location truncation in shuttle/service change titles