### PR TITLE
ai: generate calendar event titles using AWS Bedrock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -237,6 +238,33 @@ dependencies = [
  "pin-project-lite",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "aws-sdk-bedrockruntime"
+version = "1.128.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949d34a5c329ed83e7146d2fc1ffc06473fdc9bcbc5fa3d3534abeb950569c5"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body-util",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -347,6 +375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
 dependencies = [
  "aws-credential-types",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -402,11 +431,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
 dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -1687,6 +1728,8 @@ name = "mbtalerts"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aws-config",
+ "aws-sdk-bedrockruntime",
  "chrono",
  "clap",
  "gcp_auth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,10 @@ path = "src/lambda.rs"
 
 [dependencies]
 anyhow = "1.0"
+aws-config = "1"
+aws-sdk-bedrockruntime = "1"
 chrono = "0.4"
-clap = { version = "4.5", features = ["env"] }
+clap = { version = "4.6", features = ["env"] }
 gcp_auth = "0.12"
 jluszcz_rust_utils = { git = "https://github.com//jluszcz/rust-utils", features = ["query"] }
 lambda_runtime = "1.*"

--- a/mbtalerts.tf
+++ b/mbtalerts.tf
@@ -90,6 +90,24 @@ resource "aws_iam_role_policy_attachment" "basic_execution_role_attachment" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
+data "aws_iam_policy_document" "bedrock" {
+  statement {
+    actions   = ["bedrock:InvokeModel"]
+    # Cross-region inference profiles route through multiple regions, so the wildcard region is required.
+    resources = ["arn:aws:bedrock:*::foundation-model/amazon.nova-2-lite-v1:0"]
+  }
+}
+
+resource "aws_iam_policy" "bedrock" {
+  name   = "mbtalerts.bedrock"
+  policy = data.aws_iam_policy_document.bedrock.json
+}
+
+resource "aws_iam_role_policy_attachment" "bedrock" {
+  role       = aws_iam_role.role.name
+  policy_arn = aws_iam_policy.bedrock.arn
+}
+
 resource "aws_lambda_function" "mbtalerts" {
   function_name = "mbtalerts"
   s3_bucket     = data.aws_s3_bucket.code_bucket.bucket
@@ -100,7 +118,7 @@ resource "aws_lambda_function" "mbtalerts" {
   handler       = "ignored"
   publish       = "false"
   description   = "Sync MBTA Alerts against Google Calendars"
-  timeout       = 30
+  timeout       = 60
   memory_size   = 128
 
   environment {

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -1,0 +1,68 @@
+use anyhow::{Result, anyhow};
+use aws_sdk_bedrockruntime::types::{ContentBlock, ConversationRole, Message};
+use log::{debug, warn};
+
+use crate::calendar::strip_line_prefix;
+
+const DEFAULT_MODEL_ID: &str = "us.amazon.nova-2-lite-v1:0";
+
+pub struct BedrockSummarizer {
+    client: aws_sdk_bedrockruntime::Client,
+    model_id: String,
+}
+
+impl BedrockSummarizer {
+    pub async fn from_env() -> Result<Self> {
+        let config = aws_config::from_env().load().await;
+        let client = aws_sdk_bedrockruntime::Client::new(&config);
+        let model_id =
+            std::env::var("BEDROCK_MODEL_ID").unwrap_or_else(|_| DEFAULT_MODEL_ID.to_owned());
+        Ok(Self { client, model_id })
+    }
+
+    pub async fn try_init() -> Option<Self> {
+        Self::from_env()
+            .await
+            .map_err(|e| {
+                warn!("Bedrock unavailable, falling back to hardcoded summaries: {e}");
+                e
+            })
+            .ok()
+    }
+
+    pub async fn generate_summary(&self, header: &str) -> Result<String> {
+        let prompt = format!(
+            "Create a concise summary title for the following public transit alert, \
+             suitable for a calendar event title. The title should be brief (under 60 \
+             characters), informative, and focus on the key disruption type and location \
+             if relevant. Use Title Case. Do not include the line name (e.g. \"Red Line\", \
+             \"Green Line\") or dates and times — the line and date are already shown \
+             separately in the calendar. Respond with only the title text, no quotes or \
+             explanation.\n\nAlert: {header}"
+        );
+
+        let message = Message::builder()
+            .role(ConversationRole::User)
+            .content(ContentBlock::Text(prompt))
+            .build()?;
+
+        let response = self
+            .client
+            .converse()
+            .model_id(&self.model_id)
+            .messages(message)
+            .send()
+            .await?;
+
+        let text = response
+            .output()
+            .and_then(|o| o.as_message().ok())
+            .and_then(|m| m.content().first())
+            .and_then(|b| b.as_text().ok())
+            .map(|s| strip_line_prefix(s.trim()).to_owned())
+            .ok_or_else(|| anyhow!("Unexpected Bedrock response structure"))?;
+
+        debug!("Bedrock summary for {:?}: {:?}", header, text);
+        Ok(text)
+    }
+}

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use std::sync::Arc;
 
+use crate::ai::BedrockSummarizer;
 use crate::types::{Alert, Alerts};
 
 const CAL_API: &str = "https://www.googleapis.com/calendar/v3/calendars";
@@ -51,6 +52,7 @@ pub struct CalendarClient {
     token_provider: Arc<dyn TokenProvider>,
     config: CalendarConfig,
     client: Client,
+    summarizer: Option<BedrockSummarizer>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -80,6 +82,24 @@ impl CalendarEvent {
             .private
             .as_ref()?
             .get("mbta_alert_id")
+            .map(String::as_str)
+    }
+
+    fn ai_summary(&self) -> Option<&str> {
+        self.extended_properties
+            .as_ref()?
+            .private
+            .as_ref()?
+            .get("mbta_ai_summary")
+            .map(String::as_str)
+    }
+
+    fn alert_header_hash(&self) -> Option<&str> {
+        self.extended_properties
+            .as_ref()?
+            .private
+            .as_ref()?
+            .get("mbta_alert_header_hash")
             .map(String::as_str)
     }
 }
@@ -122,10 +142,13 @@ impl CalendarClient {
             CalendarConfig::Single(normalize_calendar_id(id))
         };
 
+        let summarizer = BedrockSummarizer::try_init().await;
+
         Ok(Self {
             token_provider,
             config,
             client: Client::new(),
+            summarizer,
         })
     }
 
@@ -174,15 +197,16 @@ impl CalendarClient {
         &self,
         calendar_id: &str,
         alert: &Alert,
-        line_prefix: LinePrefixMode,
+        summary: &str,
+        ai_summary_raw: Option<&str>,
     ) -> Result<()> {
         let events_url = format!("{}/{}/events", CAL_API, calendar_id);
         debug!("Creating calendar event for alert {}", alert.id);
-        self.send_authenticated(
-            self.client
-                .post(&events_url)
-                .json(&event_body(alert, line_prefix)),
-        )
+        self.send_authenticated(self.client.post(&events_url).json(&event_body(
+            alert,
+            summary,
+            ai_summary_raw,
+        )))
         .await?;
         info!("Created calendar event for alert {}", alert.id);
         Ok(())
@@ -193,15 +217,16 @@ impl CalendarClient {
         calendar_id: &str,
         event_id: &str,
         alert: &Alert,
-        line_prefix: LinePrefixMode,
+        summary: &str,
+        ai_summary_raw: Option<&str>,
     ) -> Result<()> {
         let event_url = format!("{}/{}/events/{}", CAL_API, calendar_id, event_id);
         debug!("Updating calendar event {event_id} for alert {}", alert.id);
-        self.send_authenticated(
-            self.client
-                .put(&event_url)
-                .json(&event_body(alert, line_prefix)),
-        )
+        self.send_authenticated(self.client.put(&event_url).json(&event_body(
+            alert,
+            summary,
+            ai_summary_raw,
+        )))
         .await?;
         info!("Updated calendar event {event_id} for alert {}", alert.id);
         Ok(())
@@ -223,6 +248,10 @@ const STATION_EFFECTS_TO_SKIP: &[&str] = &[
     "STATION_CLOSURE",
     "PARKING_ISSUE",
 ];
+
+pub fn should_sync_alert(alert: &Alert) -> bool {
+    !STATION_EFFECTS_TO_SKIP.contains(&alert.attributes.effect.as_str())
+}
 
 fn calendar_ids_for_alert<'a>(alert: &Alert, config: &'a CalendarConfig) -> Vec<&'a str> {
     match config {
@@ -285,7 +314,7 @@ pub async fn sync_alerts(alerts: &Alerts, cal: &CalendarClient) -> Result<()> {
         .data
         .iter()
         .filter(|a| {
-            if STATION_EFFECTS_TO_SKIP.contains(&a.attributes.effect.as_str()) {
+            if !should_sync_alert(a) {
                 debug!(
                     "Skipping station issue alert {}: {}",
                     a.id, a.attributes.effect
@@ -331,10 +360,18 @@ fn line_prefix_for_alert(
 async fn sync_calendar(cal: &CalendarClient, calendar_id: &str, alerts: &[&Alert]) -> Result<()> {
     let existing = cal.list_alert_events(calendar_id).await?;
 
-    let mut existing_by_alert_id: HashMap<String, String> = HashMap::new();
+    let mut existing_by_alert_id: HashMap<String, (String, Option<String>, Option<String>)> =
+        HashMap::new();
     for event in &existing {
         if let Some(alert_id) = event.alert_id() {
-            existing_by_alert_id.insert(alert_id.to_owned(), event.id.clone());
+            existing_by_alert_id.insert(
+                alert_id.to_owned(),
+                (
+                    event.id.clone(),
+                    event.ai_summary().map(str::to_owned),
+                    event.alert_header_hash().map(str::to_owned),
+                ),
+            );
         }
     }
 
@@ -342,19 +379,41 @@ async fn sync_calendar(cal: &CalendarClient, calendar_id: &str, alerts: &[&Alert
 
     for alert in alerts {
         let line_prefix = line_prefix_for_alert(alert, calendar_id, &cal.config);
-        let summary = event_summary(alert, line_prefix);
-        if let Some(event_id) = existing_by_alert_id.get(&alert.id) {
-            debug!("Updating event for alert {}: {}", alert.id, summary);
-            cal.update_event(calendar_id, event_id, alert, line_prefix)
-                .await?;
+
+        let (ai_summary_raw, display_summary) = match existing_by_alert_id.get(&alert.id) {
+            Some((_, Some(cached), Some(cached_hash)))
+                if cached_hash == &header_hash(&alert.attributes.header) =>
+            {
+                let display = apply_line_prefix(cached, alert, line_prefix);
+                (Some(cached.clone()), display)
+            }
+            _ => generate_or_fallback(cal.summarizer.as_ref(), alert, line_prefix).await,
+        };
+
+        if let Some((event_id, _, _)) = existing_by_alert_id.get(&alert.id) {
+            debug!("Updating event for alert {}: {}", alert.id, display_summary);
+            cal.update_event(
+                calendar_id,
+                event_id,
+                alert,
+                &display_summary,
+                ai_summary_raw.as_deref(),
+            )
+            .await?;
         } else {
-            debug!("Creating event for alert {}: {}", alert.id, summary);
-            cal.create_event(calendar_id, alert, line_prefix).await?;
+            debug!("Creating event for alert {}: {}", alert.id, display_summary);
+            cal.create_event(
+                calendar_id,
+                alert,
+                &display_summary,
+                ai_summary_raw.as_deref(),
+            )
+            .await?;
         }
         seen.insert(alert.id.clone());
     }
 
-    for (alert_id, event_id) in &existing_by_alert_id {
+    for (alert_id, (event_id, _, _)) in &existing_by_alert_id {
         if !seen.contains(alert_id) {
             info!("Deleting stale event for alert {}", alert_id);
             cal.delete_event(calendar_id, event_id).await?;
@@ -362,6 +421,32 @@ async fn sync_calendar(cal: &CalendarClient, calendar_id: &str, alerts: &[&Alert
     }
 
     Ok(())
+}
+
+fn apply_line_prefix(raw: &str, alert: &Alert, mode: LinePrefixMode) -> String {
+    match mode {
+        LinePrefixMode::Include => format!("[{}] {}", crate::line_name(alert), raw),
+        LinePrefixMode::Omit => raw.to_owned(),
+    }
+}
+
+async fn generate_or_fallback(
+    summarizer: Option<&BedrockSummarizer>,
+    alert: &Alert,
+    line_prefix: LinePrefixMode,
+) -> (Option<String>, String) {
+    if let Some(s) = summarizer {
+        match s.generate_summary(&alert.attributes.header).await {
+            Ok(raw) => {
+                let display = apply_line_prefix(&raw, alert, line_prefix);
+                return (Some(raw), display);
+            }
+            Err(e) => {
+                warn!("Bedrock inference failed for alert {}: {e:#}", alert.id);
+            }
+        }
+    }
+    (None, event_summary(alert, line_prefix))
 }
 
 fn next_date(date: &str) -> String {
@@ -393,7 +478,7 @@ fn event_times(start: Option<&str>, end: Option<&str>) -> (Value, Value) {
     }
 }
 
-fn strip_line_prefix(header: &str) -> &str {
+pub fn strip_line_prefix(header: &str) -> &str {
     if let Some(colon_idx) = header.find(": ") {
         let prefix = &header[..colon_idx];
         if prefix.contains("Line") && prefix.len() <= 35 {
@@ -548,20 +633,38 @@ fn event_description(alert: &Alert) -> String {
     parts.join("\n\n")
 }
 
-fn event_body(alert: &Alert, line_prefix: LinePrefixMode) -> Value {
+/// FNV-1a 64-bit hash — deterministic across platforms and Rust versions.
+fn header_hash(header: &str) -> String {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in header.bytes() {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash.to_string()
+}
+
+fn event_body(alert: &Alert, summary: &str, ai_summary_raw: Option<&str>) -> Value {
     let (start, end) = event_times(alert.period_start(), alert.period_end());
 
+    let mut private = serde_json::Map::new();
+    private.insert("mbta_alert_source".to_owned(), json!("true"));
+    private.insert("mbta_alert_id".to_owned(), json!(alert.id));
+    if let Some(raw) = ai_summary_raw {
+        private.insert("mbta_ai_summary".to_owned(), json!(raw));
+        private.insert(
+            "mbta_alert_header_hash".to_owned(),
+            json!(header_hash(&alert.attributes.header)),
+        );
+    }
+
     json!({
-        "summary": event_summary(alert, line_prefix),
+        "summary": summary,
         "description": event_description(alert),
         "start": start,
         "end": end,
         "transparency": "transparent",
         "extendedProperties": {
-            "private": {
-                "mbta_alert_source": "true",
-                "mbta_alert_id": alert.id,
-            }
+            "private": Value::Object(private)
         }
     })
 }
@@ -686,7 +789,8 @@ mod test {
             Some("2024-06-01T09:00:00-04:00"),
             Some("2024-06-01T23:00:00-04:00"),
         );
-        let body = event_body(&alert, LinePrefixMode::Include);
+        let summary = event_summary(&alert, LinePrefixMode::Include);
+        let body = event_body(&alert, &summary, None);
         assert_eq!(body["summary"], "[Red Line] Test header");
     }
 
@@ -699,7 +803,8 @@ mod test {
             Some("2026-02-23T13:47:00-05:00"),
         );
         alert.attributes.header = "Red Line Braintree Branch: Delays of about 20 minutes due to a signal problem at Braintree.".to_owned();
-        let body = event_body(&alert, LinePrefixMode::Include);
+        let summary = event_summary(&alert, LinePrefixMode::Include);
+        let body = event_body(&alert, &summary, None);
         assert_eq!(body["summary"], "[Red Line] Delay ~20 minutes");
     }
 
@@ -712,7 +817,8 @@ mod test {
             Some("2026-02-23T13:47:00-05:00"),
         );
         alert.attributes.header = "Blue Line: Delays of up to 20 minutes due to signal problem near Wonderland. Trains may stand by at stations.".to_owned();
-        let body = event_body(&alert, LinePrefixMode::Include);
+        let summary = event_summary(&alert, LinePrefixMode::Include);
+        let body = event_body(&alert, &summary, None);
         assert_eq!(body["summary"], "[Blue Line] Delay ~20 minutes");
     }
 
@@ -724,7 +830,8 @@ mod test {
             Some("2024-06-01T09:00:00-04:00"),
             None,
         );
-        let body = event_body(&alert, LinePrefixMode::Include);
+        let summary = event_summary(&alert, LinePrefixMode::Include);
+        let body = event_body(&alert, &summary, None);
         assert_eq!(body["summary"], "[Green Line] Test header");
     }
 
@@ -737,7 +844,8 @@ mod test {
             Some("2026-02-24T02:59:00-05:00"),
         );
         alert.attributes.header = "Due to severe weather, Subway, Bus, and Commuter Rail are operating on a reduced schedule. Ferry service is canceled.".to_owned();
-        let body = event_body(&alert, LinePrefixMode::Include);
+        let summary = event_summary(&alert, LinePrefixMode::Include);
+        let body = event_body(&alert, &summary, None);
         assert_eq!(
             body["summary"],
             "[MBTA] Due to severe weather, Subway, Bus, and Commuter Rail are operating on a reduced schedule"
@@ -753,7 +861,8 @@ mod test {
             Some("2024-06-01T23:00:00-04:00"),
         );
         alert.attributes.header = "Red Line: Shuttle buses will replace service between Broadway and Ashmont this weekend.".to_owned();
-        let body = event_body(&alert, LinePrefixMode::Include);
+        let summary = event_summary(&alert, LinePrefixMode::Include);
+        let body = event_body(&alert, &summary, None);
         assert_eq!(
             body["summary"],
             "[Red Line] Shuttle between Broadway and Ashmont"
@@ -769,7 +878,8 @@ mod test {
             None,
         );
         alert.attributes.header = "Jackson Square: The stairway connecting the Jackson Sq lobby and the south end of the platform is closed until winter 2026. Use the stairway at the north end of the platform.".to_owned();
-        let body = event_body(&alert, LinePrefixMode::Include);
+        let summary = event_summary(&alert, LinePrefixMode::Include);
+        let body = event_body(&alert, &summary, None);
         assert_eq!(
             body["summary"],
             "[Orange Line] Jackson Square: The stairway connecting the Jackson Sq lobby and the south end of the platform is closed until winter 2026"
@@ -785,7 +895,8 @@ mod test {
             Some("2026-02-25T08:27:00-05:00"),
         );
         alert.attributes.header = "Blue Line: Shuttle buses replacing service between Suffolk Downs and Maverick due to a power problem at Airport.".to_owned();
-        let body = event_body(&alert, LinePrefixMode::Include);
+        let summary = event_summary(&alert, LinePrefixMode::Include);
+        let body = event_body(&alert, &summary, None);
         assert_eq!(
             body["summary"],
             "[Blue Line] Shuttle between Suffolk Downs and Maverick"
@@ -801,7 +912,8 @@ mod test {
             Some("2024-06-01T23:00:00-04:00"),
         );
         alert.attributes.header = "Red Line Ashmont Branch: Service between JFK/UMass and Ashmont will operate with two shuttle trains from April 10 - 30 to allow for critical track work.".to_owned();
-        let body = event_body(&alert, LinePrefixMode::Include);
+        let summary = event_summary(&alert, LinePrefixMode::Include);
+        let body = event_body(&alert, &summary, None);
         assert_eq!(
             body["summary"],
             "[Red Line] Service change between JFK/UMass and Ashmont"
@@ -883,7 +995,8 @@ mod test {
             Some("2026-02-23T13:47:00-05:00"),
         );
         alert.attributes.header = "Red Line Braintree Branch: Delays of about 20 minutes due to a signal problem at Braintree.".to_owned();
-        let body = event_body(&alert, LinePrefixMode::Omit);
+        let summary = event_summary(&alert, LinePrefixMode::Omit);
+        let body = event_body(&alert, &summary, None);
         assert_eq!(body["summary"], "Delay ~20 minutes");
     }
 
@@ -896,7 +1009,8 @@ mod test {
             Some("2024-06-01T23:00:00-04:00"),
         );
         alert.attributes.header = "Red Line: Shuttle buses will replace service between Broadway and Ashmont this weekend.".to_owned();
-        let body = event_body(&alert, LinePrefixMode::Omit);
+        let summary = event_summary(&alert, LinePrefixMode::Omit);
+        let body = event_body(&alert, &summary, None);
         assert_eq!(body["summary"], "Shuttle between Broadway and Ashmont");
     }
 
@@ -908,7 +1022,8 @@ mod test {
             Some("2024-06-01T09:00:00-04:00"),
             Some("2024-06-01T23:00:00-04:00"),
         );
-        let body = event_body(&alert, LinePrefixMode::Omit);
+        let summary = event_summary(&alert, LinePrefixMode::Omit);
+        let body = event_body(&alert, &summary, None);
         assert_eq!(body["summary"], "Test header");
     }
 
@@ -1178,7 +1293,8 @@ mod test {
             Some("2024-06-01T09:00:00-04:00"),
             Some("2024-06-01T23:00:00-04:00"),
         );
-        let body = event_body(&alert, LinePrefixMode::Include);
+        let summary = event_summary(&alert, LinePrefixMode::Include);
+        let body = event_body(&alert, &summary, None);
         assert_eq!(body["description"], "Test header\n\nTest description");
     }
 
@@ -1190,7 +1306,8 @@ mod test {
             Some("2024-06-01T09:00:00-04:00"),
             Some("2024-06-01T23:00:00-04:00"),
         );
-        let body = event_body(&alert, LinePrefixMode::Include);
+        let summary = event_summary(&alert, LinePrefixMode::Include);
+        let body = event_body(&alert, &summary, None);
         assert_eq!(
             body["start"],
             json!({ "dateTime": "2024-06-01T09:00:00-04:00", "timeZone": "America/New_York" })
@@ -1204,29 +1321,48 @@ mod test {
     #[test]
     fn test_event_body_dates_when_no_end() {
         let alert = make_alert("Red", "DELAY", Some("2024-06-01T09:00:00-04:00"), None);
-        let body = event_body(&alert, LinePrefixMode::Include);
+        let summary = event_summary(&alert, LinePrefixMode::Include);
+        let body = event_body(&alert, &summary, None);
         assert_eq!(body["start"], json!({ "date": "2024-06-01" }));
         assert_eq!(body["end"], json!({ "date": "2024-06-02" }));
     }
 
     #[test]
-    fn test_event_body_extended_properties() {
+    fn test_event_body_extended_properties_without_ai_summary() {
         let alert = make_alert(
             "Red",
             "DELAY",
             Some("2024-06-01T09:00:00-04:00"),
             Some("2024-06-01T23:00:00-04:00"),
         );
-        let body = event_body(&alert, LinePrefixMode::Include);
+        let summary = event_summary(&alert, LinePrefixMode::Include);
+        let body = event_body(&alert, &summary, None);
         let private = &body["extendedProperties"]["private"];
         assert_eq!(private["mbta_alert_source"], "true");
         assert_eq!(private["mbta_alert_id"], "alert-42");
+        assert!(private.get("mbta_ai_summary").is_none());
+    }
+
+    #[test]
+    fn test_event_body_extended_properties_with_ai_summary() {
+        let alert = make_alert(
+            "Red",
+            "DELAY",
+            Some("2024-06-01T09:00:00-04:00"),
+            Some("2024-06-01T23:00:00-04:00"),
+        );
+        let body = event_body(&alert, "AI-generated title", Some("AI-generated title"));
+        let private = &body["extendedProperties"]["private"];
+        assert_eq!(private["mbta_alert_source"], "true");
+        assert_eq!(private["mbta_alert_id"], "alert-42");
+        assert_eq!(private["mbta_ai_summary"], "AI-generated title");
     }
 
     #[test]
     fn test_event_body_no_period_falls_back_to_today() {
         let alert = make_alert_no_period("Orange", "SUSPENSION");
-        let body = event_body(&alert, LinePrefixMode::Include);
+        let summary = event_summary(&alert, LinePrefixMode::Include);
+        let body = event_body(&alert, &summary, None);
         assert!(body["start"].get("date").is_some());
         assert!(body["end"].get("date").is_some());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use log::{trace, warn};
 use crate::mbta::query_subway_alerts;
 use crate::types::{Alert, Alerts};
 
+pub mod ai;
 pub mod calendar;
 pub mod mbta;
 pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
 use chrono::DateTime;
 use clap::{Arg, ArgAction, Command};
 use jluszcz_rust_utils::{Verbosity, set_up_logger};
-use log::debug;
+use log::{debug, warn};
 use mbtalerts::APP_NAME;
+use mbtalerts::ai::BedrockSummarizer;
 use mbtalerts::calendar::{
-    CalendarClient, LinePrefixMode, event_summary, first_sentence, sync_alerts,
+    CalendarClient, LinePrefixMode, event_summary, first_sentence, should_sync_alert, sync_alerts,
     uses_first_sentence_summary,
 };
 use mbtalerts::types::Alerts;
@@ -62,12 +63,26 @@ fn format_dt(s: &str) -> String {
         .unwrap_or_else(|_| s.to_owned())
 }
 
-fn format_alert(alert: &mbtalerts::types::Alert) -> String {
+async fn format_alert(
+    alert: &mbtalerts::types::Alert,
+    summarizer: Option<&BedrockSummarizer>,
+) -> String {
     let effect = &alert.attributes.effect;
     let start = alert.period_start().map(format_dt);
     let end = alert.period_end().map(format_dt);
 
-    let summary = event_summary(alert, LinePrefixMode::Include);
+    let summary = if let Some(s) = summarizer {
+        match s.generate_summary(&alert.attributes.header).await {
+            Ok(raw) => format!("[{}] {}", mbtalerts::line_name(alert), raw),
+            Err(e) => {
+                warn!("Bedrock inference failed for alert {}: {e:#}", alert.id);
+                event_summary(alert, LinePrefixMode::Include)
+            }
+        }
+    } else {
+        event_summary(alert, LinePrefixMode::Include)
+    };
+
     let formatted_summary = if let Some(close) = summary.find(']') {
         let (prefix, rest) = summary.split_at(close + 1);
         format!("\x1b[1m{prefix}\x1b[22m{rest}")
@@ -93,15 +108,15 @@ fn format_alert(alert: &mbtalerts::types::Alert) -> String {
     format!("{formatted_summary}{date_part}\n{effect} {body}")
 }
 
-fn print_alerts(alerts: &Alerts) {
-    if alerts.data.is_empty() {
-        println!("No active alerts.");
-        return;
-    }
-
-    for alert in &alerts.data {
+async fn print_alerts(alerts: &Alerts, summarizer: Option<&BedrockSummarizer>) {
+    let mut printed = false;
+    for alert in alerts.data.iter().filter(|a| should_sync_alert(a)) {
         println!("{SEPARATOR}");
-        println!("{}", format_alert(alert));
+        println!("{}", format_alert(alert, summarizer).await);
+        printed = true;
+    }
+    if !printed {
+        println!("No active alerts.");
     }
 }
 
@@ -119,7 +134,8 @@ async fn main() -> anyhow::Result<()> {
         let calendar = CalendarClient::from_env().await?;
         sync_alerts(&alerts, &calendar).await?;
     } else {
-        print_alerts(&alerts);
+        let summarizer = BedrockSummarizer::try_init().await;
+        print_alerts(&alerts, summarizer.as_ref()).await;
     }
 
     Ok(())
@@ -178,15 +194,15 @@ mod test {
 
     // --- format_alert ---
 
-    #[test]
-    fn test_format_alert_with_both_times() {
+    #[tokio::test]
+    async fn test_format_alert_with_both_times() {
         let alert = make_alert(
             "Red",
             "DELAY",
             Some("2024-06-01T09:00:00-04:00"),
             Some("2024-06-01T23:00:00-04:00"),
         );
-        let output = format_alert(&alert);
+        let output = format_alert(&alert, None).await;
         assert!(output.contains("DELAY"));
         assert!(output.contains("Red Line"));
         assert!(output.contains("6/1/2024 9:00am"));
@@ -194,8 +210,8 @@ mod test {
         assert!(output.contains("Service disruption in effect"));
     }
 
-    #[test]
-    fn test_format_alert_no_period_shows_no_dates() {
+    #[tokio::test]
+    async fn test_format_alert_no_period_shows_no_dates() {
         let alert = Alert {
             id: "test-id".to_owned(),
             attributes: AlertAttributes {
@@ -209,21 +225,21 @@ mod test {
                 }],
             },
         };
-        let output = format_alert(&alert);
+        let output = format_alert(&alert, None).await;
         assert!(output.contains("SUSPENSION"));
         assert!(output.contains("Orange Line"));
         assert!(!output.contains('('));
     }
 
-    #[test]
-    fn test_format_alert_green_line() {
+    #[tokio::test]
+    async fn test_format_alert_green_line() {
         let alert = make_alert(
             "Green-D",
             "DETOUR",
             Some("2024-06-01T08:00:00-04:00"),
             Some("2024-06-01T20:00:00-04:00"),
         );
-        let output = format_alert(&alert);
+        let output = format_alert(&alert, None).await;
         assert!(output.contains("Green Line"));
         assert!(output.contains("DETOUR"));
     }


### PR DESCRIPTION
Adds a BedrockSummarizer that calls the Bedrock Converse API to produce concise AI-generated titles for MBTA alerts. Falls back to hardcoded summaries when Bedrock is unavailable or inference fails.

Key design points:
- Raw AI summary (without line prefix) is cached in the calendar event's extendedProperties alongside a FNV-1a hash of the alert header; the cache is invalidated when the header changes
- Line prefixes added by the model are stripped post-response via the existing strip_line_prefix helper
- Initializer deduplication: BedrockSummarizer::try_init() shared by both the calendar sync and CLI print paths
- Station-issue alerts (STATION_ISSUE, STOP_CLOSURE, etc.) are now filtered before inference in both paths
- IAM policy and Lambda timeout updated in Terraform; model is us.amazon.nova-lite-v1:0