### PR TITLE
cleanup: derive CLI version from Cargo.toml, drop unused clap env fea…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,7 +1565,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 [[package]]
 name = "jluszcz_rust_utils"
 version = "0.1.0"
-source = "git+https://github.com//jluszcz/rust-utils#eaa5adecedf3b57d1cd97e52a65ca8935046ff55"
+source = "git+https://github.com/jluszcz/rust-utils#eaa5adecedf3b57d1cd97e52a65ca8935046ff55"
 dependencies = [
  "anyhow",
  "backon",
@@ -1730,6 +1740,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",
  "chrono",
+ "chrono-tz",
  "clap",
  "futures",
  "gcp_auth",
@@ -1829,6 +1840,24 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -2389,6 +2418,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ anyhow = "1"
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-bedrockruntime = { version = "1", features = ["behavior-version-latest"] }
 chrono = "0"
-clap = { version = "4", features = ["env"] }
+chrono-tz = "0"
+clap = "4"
 futures = "0"
 gcp_auth = "0"
-jluszcz_rust_utils = { git = "https://github.com//jluszcz/rust-utils", features = ["query"] }
+jluszcz_rust_utils = { git = "https://github.com/jluszcz/rust-utils", features = ["query"] }
 lambda_runtime = "1"
 log = "0"
 reqwest = { version = "0", features = ["gzip", "json"] }

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -62,7 +62,7 @@ impl BedrockSummarizer {
             .map(|s| strip_line_prefix(s.trim()).to_owned())
             .ok_or_else(|| anyhow!("Unexpected Bedrock response structure"))?;
 
-        debug!("Bedrock summary for {:?}: {:?}", header, text);
+        debug!("Bedrock summary for {header:?}: {text:?}");
         Ok(text)
     }
 }

--- a/src/calendar.rs
+++ b/src/calendar.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use crate::ai::BedrockSummarizer;
 use crate::summary::{LinePrefixMode, generate_or_fallback};
 use crate::types::{Alert, Alerts};
+use crate::{Line, canonical_line, should_sync_alert};
 
 const CAL_API: &str = "https://www.googleapis.com/calendar/v3/calendars";
 const SCOPES: &[&str] = &["https://www.googleapis.com/auth/calendar.events"];
@@ -18,7 +19,7 @@ const SCOPES: &[&str] = &["https://www.googleapis.com/auth/calendar.events"];
 pub enum CalendarConfig {
     Single(String),
     PerLine {
-        map: HashMap<String, String>,
+        map: HashMap<Line, String>,
         default: String,
     },
 }
@@ -93,6 +94,26 @@ fn normalize_calendar_id(id: String) -> String {
     }
 }
 
+fn parse_calendar_ids(json_str: &str) -> Result<CalendarConfig> {
+    let raw: HashMap<String, String> =
+        serde_json::from_str(json_str).context("GOOGLE_CALENDAR_IDS is not valid JSON")?;
+    let default = raw
+        .get("default")
+        .cloned()
+        .map(normalize_calendar_id)
+        .context("GOOGLE_CALENDAR_IDS must include a \"default\" key")?;
+    let map = raw
+        .into_iter()
+        .filter(|(k, _)| k != "default")
+        .map(|(k, v)| {
+            let line = Line::from_name(&k)
+                .with_context(|| format!("Unknown line '{k}' in GOOGLE_CALENDAR_IDS"))?;
+            Ok((line, normalize_calendar_id(v)))
+        })
+        .collect::<Result<_>>()?;
+    Ok(CalendarConfig::PerLine { map, default })
+}
+
 impl CalendarClient {
     pub async fn from_env() -> Result<Self> {
         let key_json = std::env::var("GOOGLE_SERVICE_ACCOUNT_KEY")
@@ -101,19 +122,7 @@ impl CalendarClient {
             Arc::new(CustomServiceAccount::from_json(&key_json)?);
 
         let config = if let Ok(json_str) = std::env::var("GOOGLE_CALENDAR_IDS") {
-            let raw: HashMap<String, String> =
-                serde_json::from_str(&json_str).context("GOOGLE_CALENDAR_IDS is not valid JSON")?;
-            let default = raw
-                .get("default")
-                .cloned()
-                .map(normalize_calendar_id)
-                .context("GOOGLE_CALENDAR_IDS must include a \"default\" key")?;
-            let map = raw
-                .into_iter()
-                .filter(|(k, _)| k != "default")
-                .map(|(k, v)| (k, normalize_calendar_id(v)))
-                .collect();
-            CalendarConfig::PerLine { map, default }
+            parse_calendar_ids(&json_str)?
         } else {
             let id = std::env::var("GOOGLE_CALENDAR_ID")
                 .context("Either GOOGLE_CALENDAR_IDS or GOOGLE_CALENDAR_ID env var must be set")?;
@@ -145,7 +154,7 @@ impl CalendarClient {
         let mut events = Vec::new();
         let mut page_token: Option<String> = None;
         let time_min = chrono::Utc::now().to_rfc3339();
-        let events_url = format!("{}/{}/events", CAL_API, calendar_id);
+        let events_url = format!("{CAL_API}/{calendar_id}/events");
 
         debug!("Listing calendar events for {calendar_id}");
         loop {
@@ -178,7 +187,7 @@ impl CalendarClient {
         summary: &str,
         ai_summary_raw: Option<&str>,
     ) -> Result<()> {
-        let events_url = format!("{}/{}/events", CAL_API, calendar_id);
+        let events_url = format!("{CAL_API}/{calendar_id}/events");
         let body = event_body(alert, summary, ai_summary_raw)?;
         self.send_authenticated(self.client.post(&events_url).json(&body))
             .await?;
@@ -194,7 +203,7 @@ impl CalendarClient {
         summary: &str,
         ai_summary_raw: Option<&str>,
     ) -> Result<()> {
-        let event_url = format!("{}/{}/events/{}", CAL_API, calendar_id, event_id);
+        let event_url = format!("{CAL_API}/{calendar_id}/events/{event_id}");
         let body = event_body(alert, summary, ai_summary_raw)?;
         self.send_authenticated(self.client.put(&event_url).json(&body))
             .await?;
@@ -203,23 +212,12 @@ impl CalendarClient {
     }
 
     async fn delete_event(&self, calendar_id: &str, event_id: &str) -> Result<()> {
-        let event_url = format!("{}/{}/events/{}", CAL_API, calendar_id, event_id);
+        let event_url = format!("{CAL_API}/{calendar_id}/events/{event_id}");
         self.send_authenticated(self.client.delete(&event_url))
             .await?;
         info!("Deleted calendar event {event_id}");
         Ok(())
     }
-}
-
-const STATION_EFFECTS_TO_SKIP: &[&str] = &[
-    "STATION_ISSUE",
-    "STOP_CLOSURE",
-    "STATION_CLOSURE",
-    "PARKING_ISSUE",
-];
-
-pub fn should_sync_alert(alert: &Alert) -> bool {
-    !STATION_EFFECTS_TO_SKIP.contains(&alert.attributes.effect.as_str())
 }
 
 fn calendar_ids_for_alert<'a>(alert: &Alert, config: &'a CalendarConfig) -> Vec<&'a str> {
@@ -234,14 +232,15 @@ fn calendar_ids_for_alert<'a>(alert: &Alert, config: &'a CalendarConfig) -> Vec<
                     continue;
                 };
                 found_any_route = true;
-                match crate::canonical_line(route) {
+                match canonical_line(route) {
                     Some(line) => {
-                        if let Some(id) = map.get(line) {
+                        if let Some(id) = map.get(&line) {
                             ids.insert(id.as_str());
                         } else {
                             warn!(
                                 "Alert {}: line '{}' not in GOOGLE_CALENDAR_IDS, using default",
-                                alert.id, line
+                                alert.id,
+                                line.name()
                             );
                             ids.insert(default.as_str());
                         }
@@ -319,8 +318,8 @@ fn line_prefix_for_alert(
     };
     for entity in &alert.attributes.informed_entity {
         let Some(route) = &entity.route else { continue };
-        if let Some(line) = crate::canonical_line(route)
-            && map.get(line).map(String::as_str) == Some(calendar_id)
+        if let Some(line) = canonical_line(route)
+            && map.get(&line).map(String::as_str) == Some(calendar_id)
         {
             return LinePrefixMode::Omit;
         }
@@ -402,27 +401,20 @@ async fn sync_calendar(cal: &CalendarClient, calendar_id: &str, alerts: &[&Alert
 
     for alert in plan.to_create {
         let line_prefix = line_prefix_for_alert(alert, calendar_id, &cal.config);
-        let (ai_summary_raw, display_summary) =
-            generate_or_fallback(cal.summarizer.as_ref(), alert, line_prefix).await;
-        cal.create_event(
-            calendar_id,
-            alert,
-            &display_summary,
-            ai_summary_raw.as_deref(),
-        )
-        .await?;
+        let summary = generate_or_fallback(cal.summarizer.as_ref(), alert, line_prefix).await;
+        cal.create_event(calendar_id, alert, &summary.display, summary.raw.as_deref())
+            .await?;
     }
 
     for (event_id, alert) in &plan.to_update {
         let line_prefix = line_prefix_for_alert(alert, calendar_id, &cal.config);
-        let (ai_summary_raw, display_summary) =
-            generate_or_fallback(cal.summarizer.as_ref(), alert, line_prefix).await;
+        let summary = generate_or_fallback(cal.summarizer.as_ref(), alert, line_prefix).await;
         cal.update_event(
             calendar_id,
             event_id,
             alert,
-            &display_summary,
-            ai_summary_raw.as_deref(),
+            &summary.display,
+            summary.raw.as_deref(),
         )
         .await?;
     }
@@ -454,7 +446,12 @@ fn event_times(start: Option<&str>, end: Option<&str>) -> Result<(Value, Value)>
             Ok((json!({ "date": date }), json!({ "date": next_date(date)? })))
         }
         _ => {
-            let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+            // Alerts are Eastern-time events; using the UTC date would roll to
+            // tomorrow after ~7-8pm ET.
+            let today = chrono::Utc::now()
+                .with_timezone(&chrono_tz::America::New_York)
+                .format("%Y-%m-%d")
+                .to_string();
             let tomorrow = next_date(&today)?;
             Ok((json!({ "date": today }), json!({ "date": tomorrow })))
         }
@@ -530,41 +527,23 @@ fn event_body(alert: &Alert, summary: &str, ai_summary_raw: Option<&str>) -> Res
 mod test {
     use super::*;
     use crate::summary::event_summary;
-    use crate::types::{ActivePeriod, AlertAttributes, InformedEntity};
 
     fn make_alert(route: &str, effect: &str, start: Option<&str>, end: Option<&str>) -> Alert {
-        Alert {
-            id: "alert-42".to_owned(),
-            attributes: AlertAttributes {
-                header: "Test header".to_owned(),
-                description: Some("Test description".to_owned()),
-                url: None,
-                active_period: vec![ActivePeriod {
-                    start: start.map(str::to_owned),
-                    end: end.map(str::to_owned),
-                }],
-                effect: effect.to_owned(),
-                informed_entity: vec![InformedEntity {
-                    route: Some(route.to_owned()),
-                }],
-            },
-        }
+        Alert::builder()
+            .id("alert-42")
+            .description("Test description")
+            .route(route)
+            .effect(effect)
+            .period(start, end)
+            .build()
     }
 
     fn make_alert_no_period(route: &str, effect: &str) -> Alert {
-        Alert {
-            id: "alert-99".to_owned(),
-            attributes: AlertAttributes {
-                header: "Test header".to_owned(),
-                description: None,
-                url: None,
-                active_period: vec![],
-                effect: effect.to_owned(),
-                informed_entity: vec![InformedEntity {
-                    route: Some(route.to_owned()),
-                }],
-            },
-        }
+        Alert::builder()
+            .id("alert-99")
+            .route(route)
+            .effect(effect)
+            .build()
     }
 
     // --- next_date ---
@@ -802,17 +781,7 @@ mod test {
 
     #[test]
     fn test_line_prefix_fallback_no_route_includes() {
-        let alert = Alert {
-            id: "x".to_owned(),
-            attributes: AlertAttributes {
-                header: "Test".to_owned(),
-                description: None,
-                url: None,
-                active_period: vec![],
-                effect: "DELAY".to_owned(),
-                informed_entity: vec![InformedEntity { route: None }],
-            },
-        };
+        let alert = Alert::builder().id("x").header("Test").null_route().build();
         assert!(matches!(
             line_prefix_for_alert(&alert, "cal-default", &per_line_config()),
             LinePrefixMode::Include
@@ -824,7 +793,7 @@ mod test {
         // Line is identified as Red but Red has no calendar mapping
         let alert = make_alert("Red", "DELAY", None, None);
         let config = CalendarConfig::PerLine {
-            map: [("Orange".to_owned(), "cal-orange".to_owned())].into(),
+            map: [(Line::Orange, "cal-orange".to_owned())].into(),
             default: "cal-default".to_owned(),
         };
         assert!(matches!(
@@ -889,33 +858,6 @@ mod test {
             event_description(&alert),
             "Header with spaces\n\nDescription with spaces"
         );
-    }
-
-    // --- STATION_EFFECTS_TO_SKIP ---
-
-    #[test]
-    fn test_station_issue_is_skipped() {
-        assert!(STATION_EFFECTS_TO_SKIP.contains(&"STATION_ISSUE"));
-    }
-
-    #[test]
-    fn test_stop_closure_is_skipped() {
-        assert!(STATION_EFFECTS_TO_SKIP.contains(&"STOP_CLOSURE"));
-    }
-
-    #[test]
-    fn test_station_closure_is_skipped() {
-        assert!(STATION_EFFECTS_TO_SKIP.contains(&"STATION_CLOSURE"));
-    }
-
-    #[test]
-    fn test_parking_issue_is_skipped() {
-        assert!(STATION_EFFECTS_TO_SKIP.contains(&"PARKING_ISSUE"));
-    }
-
-    #[test]
-    fn test_shuttle_is_not_skipped() {
-        assert!(!STATION_EFFECTS_TO_SKIP.contains(&"SHUTTLE"));
     }
 
     #[test]
@@ -1016,15 +958,46 @@ mod test {
         );
     }
 
+    // --- parse_calendar_ids ---
+
+    #[test]
+    fn test_parse_calendar_ids_per_line() -> Result<()> {
+        let config = parse_calendar_ids(r#"{"default": "cal-default", "Red": "cal-red"}"#)?;
+        let CalendarConfig::PerLine { map, default } = config else {
+            panic!("expected PerLine config");
+        };
+        assert_eq!(default, "cal-default@group.calendar.google.com");
+        assert_eq!(
+            map.get(&Line::Red).map(String::as_str),
+            Some("cal-red@group.calendar.google.com")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_calendar_ids_missing_default_errors() {
+        assert!(parse_calendar_ids(r#"{"Red": "cal-red"}"#).is_err());
+    }
+
+    #[test]
+    fn test_parse_calendar_ids_unknown_line_errors() {
+        assert!(parse_calendar_ids(r#"{"default": "cal-default", "Gren": "cal-green"}"#).is_err());
+    }
+
+    #[test]
+    fn test_parse_calendar_ids_invalid_json_errors() {
+        assert!(parse_calendar_ids("not json").is_err());
+    }
+
     // --- calendar_ids_for_alert ---
 
     fn per_line_config() -> CalendarConfig {
         CalendarConfig::PerLine {
             map: [
-                ("Red".to_owned(), "cal-red".to_owned()),
-                ("Orange".to_owned(), "cal-orange".to_owned()),
-                ("Blue".to_owned(), "cal-blue".to_owned()),
-                ("Green".to_owned(), "cal-green".to_owned()),
+                (Line::Red, "cal-red".to_owned()),
+                (Line::Orange, "cal-orange".to_owned()),
+                (Line::Blue, "cal-blue".to_owned()),
+                (Line::Green, "cal-green".to_owned()),
             ]
             .into(),
             default: "cal-default".to_owned(),
@@ -1032,36 +1005,19 @@ mod test {
     }
 
     fn make_alert_multi_route(routes: &[&str], effect: &str) -> Alert {
-        Alert {
-            id: "alert-multi".to_owned(),
-            attributes: AlertAttributes {
-                header: "Test header".to_owned(),
-                description: None,
-                url: None,
-                active_period: vec![],
-                effect: effect.to_owned(),
-                informed_entity: routes
-                    .iter()
-                    .map(|r| InformedEntity {
-                        route: Some(r.to_string()),
-                    })
-                    .collect(),
-            },
+        let mut builder = Alert::builder().id("alert-multi").effect(effect);
+        for route in routes {
+            builder = builder.route(route);
         }
+        builder.build()
     }
 
     fn make_alert_no_route(effect: &str) -> Alert {
-        Alert {
-            id: "alert-no-route".to_owned(),
-            attributes: AlertAttributes {
-                header: "Test header".to_owned(),
-                description: None,
-                url: None,
-                active_period: vec![],
-                effect: effect.to_owned(),
-                informed_entity: vec![InformedEntity { route: None }],
-            },
-        }
+        Alert::builder()
+            .id("alert-no-route")
+            .effect(effect)
+            .null_route()
+            .build()
     }
 
     #[test]
@@ -1111,7 +1067,7 @@ mod test {
     #[test]
     fn test_calendar_ids_per_line_unmapped_line_returns_default() {
         let config = CalendarConfig::PerLine {
-            map: [("Red".to_owned(), "cal-red".to_owned())].into(),
+            map: [(Line::Red, "cal-red".to_owned())].into(),
             default: "cal-default".to_owned(),
         };
         let alert = make_alert("Blue", "DELAY", None, None);
@@ -1122,8 +1078,8 @@ mod test {
     fn test_calendar_ids_per_line_deduplicates_same_calendar() {
         let config = CalendarConfig::PerLine {
             map: [
-                ("Red".to_owned(), "cal-shared".to_owned()),
-                ("Orange".to_owned(), "cal-shared".to_owned()),
+                (Line::Red, "cal-shared".to_owned()),
+                (Line::Orange, "cal-shared".to_owned()),
             ]
             .into(),
             default: "cal-default".to_owned(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,25 +13,58 @@ pub mod types;
 
 pub const APP_NAME: &str = "mbtalerts";
 
-pub fn canonical_line(route: &str) -> Option<&'static str> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Line {
+    Red,
+    Orange,
+    Blue,
+    Green,
+}
+
+impl Line {
+    pub const ALL: [Line; 4] = [Line::Red, Line::Orange, Line::Blue, Line::Green];
+
+    /// Canonical short name, used as the key in GOOGLE_CALENDAR_IDS.
+    pub fn name(self) -> &'static str {
+        match self {
+            Line::Red => "Red",
+            Line::Orange => "Orange",
+            Line::Blue => "Blue",
+            Line::Green => "Green",
+        }
+    }
+
+    /// Inverse of [`Line::name`]: parses a GOOGLE_CALENDAR_IDS key.
+    pub fn from_name(name: &str) -> Option<Line> {
+        Self::ALL.into_iter().find(|line| line.name() == name)
+    }
+
+    pub fn full_name(self) -> &'static str {
+        match self {
+            Line::Red => "Red Line",
+            Line::Orange => "Orange Line",
+            Line::Blue => "Blue Line",
+            Line::Green => "Green Line",
+        }
+    }
+}
+
+pub fn canonical_line(route: &str) -> Option<Line> {
     match route {
-        "Red" => Some("Red"),
-        "Orange" => Some("Orange"),
-        "Blue" => Some("Blue"),
-        r if r.starts_with("Green") => Some("Green"),
+        "Red" => Some(Line::Red),
+        "Orange" => Some(Line::Orange),
+        "Blue" => Some(Line::Blue),
+        r if r.starts_with("Green") => Some(Line::Green),
         _ => None,
     }
 }
 
-pub fn line_name(alert: &Alert) -> &str {
+pub fn line_name(alert: &Alert) -> &'static str {
     for entity in &alert.attributes.informed_entity {
         if let Some(route) = &entity.route {
             return match canonical_line(route) {
-                Some("Red") => "Red Line",
-                Some("Orange") => "Orange Line",
-                Some("Blue") => "Blue Line",
-                Some("Green") => "Green Line",
-                _ => {
+                Some(line) => line.full_name(),
+                None => {
                     warn!("Unknown route '{route}', falling back to MBTA");
                     "MBTA"
                 }
@@ -39,6 +72,19 @@ pub fn line_name(alert: &Alert) -> &str {
         }
     }
     "MBTA"
+}
+
+const STATION_EFFECTS_TO_SKIP: &[&str] = &[
+    "STATION_ISSUE",
+    "STOP_CLOSURE",
+    "STATION_CLOSURE",
+    "PARKING_ISSUE",
+];
+
+/// Station-level issues (closed stairways, parking, etc.) are noise for both
+/// the terminal output and calendar sync.
+pub fn should_sync_alert(alert: &Alert) -> bool {
+    !STATION_EFFECTS_TO_SKIP.contains(&alert.attributes.effect.as_str())
 }
 
 pub async fn alerts(cache_mode: CacheMode) -> Result<Alerts> {
@@ -59,85 +105,64 @@ mod test {
     const EXAMPLE_ALERTS_RESPONSE: &str = include_str!("../tests/fixtures/alerts.json");
 
     fn make_alert(route: &str) -> Alert {
-        Alert {
-            id: "test-id".to_owned(),
-            attributes: types::AlertAttributes {
-                header: "Test header".to_owned(),
-                description: None,
-                url: None,
-                active_period: vec![],
-                effect: "DELAY".to_owned(),
-                informed_entity: vec![types::InformedEntity {
-                    route: Some(route.to_owned()),
-                }],
-            },
-        }
+        Alert::builder().route(route).build()
     }
 
     fn make_alert_no_entities() -> Alert {
-        Alert {
-            id: "test-id".to_owned(),
-            attributes: types::AlertAttributes {
-                header: "Test header".to_owned(),
-                description: None,
-                url: None,
-                active_period: vec![],
-                effect: "DELAY".to_owned(),
-                informed_entity: vec![],
-            },
-        }
+        Alert::builder().build()
     }
 
     fn make_alert_null_route() -> Alert {
-        Alert {
-            id: "test-id".to_owned(),
-            attributes: types::AlertAttributes {
-                header: "Test header".to_owned(),
-                description: None,
-                url: None,
-                active_period: vec![],
-                effect: "DELAY".to_owned(),
-                informed_entity: vec![types::InformedEntity { route: None }],
-            },
-        }
+        Alert::builder().null_route().build()
     }
 
     #[test]
     fn test_deserialize() -> Result<()> {
-        let response: Result<Alerts, _> = serde_json::from_str(EXAMPLE_ALERTS_RESPONSE);
-        assert!(response.is_ok());
+        serde_json::from_str::<Alerts>(EXAMPLE_ALERTS_RESPONSE)?;
 
         Ok(())
     }
 
     #[test]
+    fn test_line_from_name_round_trips() {
+        for line in Line::ALL {
+            assert_eq!(Line::from_name(line.name()), Some(line));
+        }
+    }
+
+    #[test]
+    fn test_line_from_name_unknown() {
+        assert_eq!(Line::from_name("Silver"), None);
+    }
+
+    #[test]
     fn test_canonical_line_red() {
-        assert_eq!(canonical_line("Red"), Some("Red"));
+        assert_eq!(canonical_line("Red"), Some(Line::Red));
     }
 
     #[test]
     fn test_canonical_line_orange() {
-        assert_eq!(canonical_line("Orange"), Some("Orange"));
+        assert_eq!(canonical_line("Orange"), Some(Line::Orange));
     }
 
     #[test]
     fn test_canonical_line_blue() {
-        assert_eq!(canonical_line("Blue"), Some("Blue"));
+        assert_eq!(canonical_line("Blue"), Some(Line::Blue));
     }
 
     #[test]
     fn test_canonical_line_green() {
-        assert_eq!(canonical_line("Green"), Some("Green"));
+        assert_eq!(canonical_line("Green"), Some(Line::Green));
     }
 
     #[test]
     fn test_canonical_line_green_b() {
-        assert_eq!(canonical_line("Green-B"), Some("Green"));
+        assert_eq!(canonical_line("Green-B"), Some(Line::Green));
     }
 
     #[test]
     fn test_canonical_line_green_e() {
-        assert_eq!(canonical_line("Green-E"), Some("Green"));
+        assert_eq!(canonical_line("Green-E"), Some(Line::Green));
     }
 
     #[test]
@@ -198,5 +223,36 @@ mod test {
     #[test]
     fn test_line_name_null_route() {
         assert_eq!(line_name(&make_alert_null_route()), "MBTA");
+    }
+
+    fn make_alert_with_effect(effect: &str) -> Alert {
+        Alert::builder().route("Red").effect(effect).build()
+    }
+
+    #[test]
+    fn test_should_sync_station_issue_is_skipped() {
+        assert!(!should_sync_alert(&make_alert_with_effect("STATION_ISSUE")));
+    }
+
+    #[test]
+    fn test_should_sync_stop_closure_is_skipped() {
+        assert!(!should_sync_alert(&make_alert_with_effect("STOP_CLOSURE")));
+    }
+
+    #[test]
+    fn test_should_sync_station_closure_is_skipped() {
+        assert!(!should_sync_alert(&make_alert_with_effect(
+            "STATION_CLOSURE"
+        )));
+    }
+
+    #[test]
+    fn test_should_sync_parking_issue_is_skipped() {
+        assert!(!should_sync_alert(&make_alert_with_effect("PARKING_ISSUE")));
+    }
+
+    #[test]
+    fn test_should_sync_shuttle_is_synced() {
+        assert!(should_sync_alert(&make_alert_with_effect("SHUTTLE")));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,13 @@ use clap::{Arg, ArgAction, Command};
 use jluszcz_rust_utils::cache::CacheMode;
 use jluszcz_rust_utils::{Verbosity, set_up_logger};
 use log::debug;
-use mbtalerts::APP_NAME;
 use mbtalerts::ai::BedrockSummarizer;
-use mbtalerts::calendar::{CalendarClient, should_sync_alert, sync_alerts};
+use mbtalerts::calendar::{CalendarClient, sync_alerts};
 use mbtalerts::summary::{
     LinePrefixMode, first_sentence, generate_or_fallback, uses_first_sentence_summary,
 };
 use mbtalerts::types::Alerts;
+use mbtalerts::{APP_NAME, should_sync_alert};
 
 const SEPARATOR: &str = "----------------------------------------";
 
@@ -22,7 +22,7 @@ struct Args {
 
 fn parse_args() -> Args {
     let matches = Command::new("mbtalerts")
-        .version("0.1")
+        .version(env!("CARGO_PKG_VERSION"))
         .author("Jacob Luszcz")
         .arg(
             Arg::new("verbosity")
@@ -72,7 +72,9 @@ async fn format_alert(
     let start = alert.period_start().map(format_dt);
     let end = alert.period_end().map(format_dt);
 
-    let (_, summary) = generate_or_fallback(summarizer, alert, LinePrefixMode::Include).await;
+    let summary = generate_or_fallback(summarizer, alert, LinePrefixMode::Include)
+        .await
+        .display;
 
     let formatted_summary = if let Some(close) = summary.find(']') {
         let (prefix, rest) = summary.split_at(close + 1);
@@ -135,25 +137,15 @@ async fn main() -> anyhow::Result<()> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use mbtalerts::types::{ActivePeriod, Alert, AlertAttributes, InformedEntity};
+    use mbtalerts::types::Alert;
 
     fn make_alert(route: &str, effect: &str, start: Option<&str>, end: Option<&str>) -> Alert {
-        Alert {
-            id: "test-id".to_owned(),
-            attributes: AlertAttributes {
-                header: "Service disruption in effect".to_owned(),
-                description: None,
-                url: None,
-                active_period: vec![ActivePeriod {
-                    start: start.map(str::to_owned),
-                    end: end.map(str::to_owned),
-                }],
-                effect: effect.to_owned(),
-                informed_entity: vec![InformedEntity {
-                    route: Some(route.to_owned()),
-                }],
-            },
-        }
+        Alert::builder()
+            .header("Service disruption in effect")
+            .route(route)
+            .effect(effect)
+            .period(start, end)
+            .build()
     }
 
     // --- format_dt ---
@@ -203,19 +195,11 @@ mod test {
 
     #[tokio::test]
     async fn test_format_alert_no_period_shows_no_dates() {
-        let alert = Alert {
-            id: "test-id".to_owned(),
-            attributes: AlertAttributes {
-                header: "Some header".to_owned(),
-                description: None,
-                url: None,
-                active_period: vec![],
-                effect: "SUSPENSION".to_owned(),
-                informed_entity: vec![InformedEntity {
-                    route: Some("Orange".to_owned()),
-                }],
-            },
-        };
+        let alert = Alert::builder()
+            .header("Some header")
+            .route("Orange")
+            .effect("SUSPENSION")
+            .build();
         let output = format_alert(&alert, None).await;
         assert!(output.contains("SUSPENSION"));
         assert!(output.contains("Orange Line"));

--- a/src/mbta.rs
+++ b/src/mbta.rs
@@ -7,11 +7,7 @@ const ROUTES: &str = "Red,Orange,Blue,Green-B,Green-C,Green-D,Green-E";
 
 pub async fn query_subway_alerts() -> anyhow::Result<String> {
     debug!("Fetching MBTA subway alerts");
-    let response = http_get(
-        &format!("{}/{}", API_URL, ALERTS),
-        &[("filter[route]", ROUTES)],
-    )
-    .await?;
+    let response = http_get(&format!("{API_URL}/{ALERTS}"), &[("filter[route]", ROUTES)]).await?;
     info!("Fetched MBTA subway alerts");
     Ok(response)
 }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -122,7 +122,7 @@ pub fn event_summary(alert: &Alert, line_prefix: LinePrefixMode) -> String {
     {
         return match line_prefix {
             LinePrefixMode::Include => format!("[{}] Delay {}", crate::line_name(alert), duration),
-            LinePrefixMode::Omit => format!("Delay {}", duration),
+            LinePrefixMode::Omit => format!("Delay {duration}"),
         };
     }
     if let Some(label) = effect_label(&alert.attributes.effect)
@@ -132,7 +132,7 @@ pub fn event_summary(alert: &Alert, line_prefix: LinePrefixMode) -> String {
             LinePrefixMode::Include => {
                 format!("[{}] {} {}", crate::line_name(alert), label, loc)
             }
-            LinePrefixMode::Omit => format!("{} {}", label, loc),
+            LinePrefixMode::Omit => format!("{label} {loc}"),
         };
     }
     match line_prefix {
@@ -156,44 +156,49 @@ pub fn uses_first_sentence_summary(alert: &Alert) -> bool {
     true
 }
 
+pub struct AlertSummary {
+    /// AI-generated summary without the line prefix, when Bedrock produced one.
+    pub raw: Option<String>,
+    /// Summary to display, with the line prefix applied per `LinePrefixMode`.
+    pub display: String,
+}
+
 pub async fn generate_or_fallback(
     summarizer: Option<&BedrockSummarizer>,
     alert: &Alert,
     line_prefix: LinePrefixMode,
-) -> (Option<String>, String) {
+) -> AlertSummary {
     if let Some(s) = summarizer {
         match s.generate_summary(&alert.attributes.header).await {
             Ok(raw) => {
                 let display = apply_line_prefix(&raw, alert, line_prefix);
-                return (Some(raw), display);
+                return AlertSummary {
+                    raw: Some(raw),
+                    display,
+                };
             }
             Err(e) => {
                 warn!("Bedrock inference failed for alert {}: {e:#}", alert.id);
             }
         }
     }
-    (None, event_summary(alert, line_prefix))
+    AlertSummary {
+        raw: None,
+        display: event_summary(alert, line_prefix),
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::types::{AlertAttributes, InformedEntity};
 
     fn make_alert(route: &str, effect: &str) -> Alert {
-        Alert {
-            id: "alert-42".to_owned(),
-            attributes: AlertAttributes {
-                header: "Test header".to_owned(),
-                description: Some("Test description".to_owned()),
-                url: None,
-                active_period: vec![],
-                effect: effect.to_owned(),
-                informed_entity: vec![InformedEntity {
-                    route: Some(route.to_owned()),
-                }],
-            },
-        }
+        Alert::builder()
+            .id("alert-42")
+            .description("Test description")
+            .route(route)
+            .effect(effect)
+            .build()
     }
 
     // --- effect_label ---

--- a/src/types.rs
+++ b/src/types.rs
@@ -40,4 +40,91 @@ impl Alert {
     pub fn period_end(&self) -> Option<&str> {
         self.attributes.active_period.first()?.end.as_deref()
     }
+
+    /// Builder with placeholder defaults, intended for tests. Production
+    /// alerts are deserialized from the MBTA API.
+    pub fn builder() -> AlertBuilder {
+        AlertBuilder {
+            id: "test-id".to_owned(),
+            header: "Test header".to_owned(),
+            description: None,
+            url: None,
+            active_period: Vec::new(),
+            effect: "DELAY".to_owned(),
+            informed_entity: Vec::new(),
+        }
+    }
+}
+
+pub struct AlertBuilder {
+    id: String,
+    header: String,
+    description: Option<String>,
+    url: Option<String>,
+    active_period: Vec<ActivePeriod>,
+    effect: String,
+    informed_entity: Vec<InformedEntity>,
+}
+
+impl AlertBuilder {
+    pub fn id(mut self, id: &str) -> Self {
+        self.id = id.to_owned();
+        self
+    }
+
+    pub fn header(mut self, header: &str) -> Self {
+        self.header = header.to_owned();
+        self
+    }
+
+    pub fn description(mut self, description: &str) -> Self {
+        self.description = Some(description.to_owned());
+        self
+    }
+
+    pub fn url(mut self, url: &str) -> Self {
+        self.url = Some(url.to_owned());
+        self
+    }
+
+    pub fn effect(mut self, effect: &str) -> Self {
+        self.effect = effect.to_owned();
+        self
+    }
+
+    /// Adds an informed entity for `route`; call repeatedly for multi-route alerts.
+    pub fn route(mut self, route: &str) -> Self {
+        self.informed_entity.push(InformedEntity {
+            route: Some(route.to_owned()),
+        });
+        self
+    }
+
+    /// Adds an informed entity with no route.
+    pub fn null_route(mut self) -> Self {
+        self.informed_entity.push(InformedEntity { route: None });
+        self
+    }
+
+    pub fn period(mut self, start: Option<&str>, end: Option<&str>) -> Self {
+        self.active_period.push(ActivePeriod {
+            start: start.map(str::to_owned),
+            end: end.map(str::to_owned),
+        });
+        self
+    }
+
+    pub fn build(self) -> Alert {
+        Alert {
+            id: self.id,
+            attributes: AlertAttributes {
+                header: self.header,
+                description: self.description,
+                url: self.url,
+                active_period: self.active_period,
+                effect: self.effect,
+                informed_entity: self.informed_entity,
+            },
+        }
+    }
 }


### PR DESCRIPTION
…ture, fix dep URL

fix: use Eastern time for all-day event date fallback

Alerts with no active period fell back to the UTC date, which is already tomorrow after ~7-8pm ET.

refactor: introduce Line enum, move alert filtering into lib

canonical_line now returns a Line enum instead of stringly-typed names, removing the duplicated route-name mapping in line_name and calendar lookups. should_sync_alert moves to lib since it gates terminal output as well as calendar sync; its tests now exercise the function instead of the skip-list contents.

refactor: return named AlertSummary struct from generate_or_fallback

Replaces the (Option<String>, String) tuple so callers don't need to remember which element is the raw AI summary vs the display string.

tests: share an Alert builder across test modules

Replaces five near-identical hand-rolled Alert constructors with a single builder on Alert (placeholder defaults, intended for tests; it lives in types.rs rather than behind cfg(test) so the bin crate's tests can use it too). Also let test_deserialize propagate the serde error instead of asserting is_ok, so failures show the actual parse error.

style: inline format args consistently

Applies clippy::uninlined_format_args across the codebase so format strings use inline captures where possible.

refactor: key per-line calendar config by Line enum

Replaces the stringly-typed HashMap<String, String> seam between the Line enum and GOOGLE_CALENDAR_IDS lookups. Config parsing moves into a testable parse_calendar_ids, which now rejects unknown line keys instead of silently ignoring them.