### PR TITLE
chore: rename CI workflow to ci.yml and normalize build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy
+name: CI
 
 on:
   push:
@@ -18,7 +18,8 @@ env:
   PROJECT: mbtalerts
 
 jobs:
-  build-and-package:
+  build:
+    name: Build, Test & Lint
     runs-on: ubuntu-24.04-arm
 
     permissions:
@@ -69,7 +70,7 @@ jobs:
           retention-days: 1
 
   deploy:
-    needs: build-and-package
+    needs: build
 
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mbtalerts
 
-[![Build and Deploy](https://github.com/jluszcz/mbtalerts/actions/workflows/build-and-deploy.yml/badge.svg)](https://github.com/jluszcz/mbtalerts/actions/workflows/build-and-deploy.yml)
+[![CI](https://github.com/jluszcz/mbtalerts/actions/workflows/ci.yml/badge.svg)](https://github.com/jluszcz/mbtalerts/actions/workflows/ci.yml)
 
 Fetches active MBTA subway alerts (Red, Orange, Blue, and Green Lines) from the [MBTA v3 API](https://api-v3.mbta.com) and displays them in the terminal.
 


### PR DESCRIPTION
Rename build-and-deploy.yml to ci.yml and rename the build-and-package job to build (with an explicit "Build, Test & Lint" name) so the check name is consistent across repos.