### PR TITLE
chore(cli): infer long args and lint test code in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get install -y musl-tools
           rustup target add ${{ env.BUILD_TARGET }}
           rustup update
-          rustup component add clippy
+          rustup component add clippy rustfmt
 
       - name: Dump Toolchain Info
         run: |
@@ -51,8 +51,11 @@ jobs:
       - name: Test
         run: cargo test --target ${{ env.BUILD_TARGET }}
 
+      - name: Format
+        run: cargo fmt --check
+
       - name: Lint
-        run: cargo clippy --target ${{ env.BUILD_TARGET }} -- -D warnings
+        run: cargo clippy --target ${{ env.BUILD_TARGET }} --all-targets -- -D warnings
 
       - name: Package
         if: github.event_name == 'push'

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ fn parse_args() -> Args {
     let matches = Command::new("mbtalerts")
         .version(env!("CARGO_PKG_VERSION"))
         .author("Jacob Luszcz")
+        .infer_long_args(true)
         .arg(
             Arg::new("verbosity")
                 .short('v')


### PR DESCRIPTION
Add infer_long_args to the clap Command so unambiguous long-flag prefixes work, and add a Format (cargo fmt --check) CI step before Lint, plus lint test code (--all-targets).