### PR TITLE
chore(cli): switch clap to derive-based argument parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -745,6 +746,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1223,6 +1236,12 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-bedrockruntime = { version = "1", features = ["behavior-version-latest"] }
 chrono = "0"
 chrono-tz = "0"
-clap = "4"
+clap = { version = "4", features = ["derive"] }
 futures = "0"
 gcp_auth = "0"
 jluszcz_rust_utils = { git = "https://github.com/jluszcz/rust-utils", features = ["query"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use chrono::DateTime;
-use clap::{Arg, ArgAction, Command};
+use clap::Parser;
 use jluszcz_rust_utils::cache::CacheMode;
 use jluszcz_rust_utils::{Verbosity, set_up_logger};
 use log::debug;
@@ -13,6 +13,22 @@ use mbtalerts::{APP_NAME, should_sync_alert};
 
 const SEPARATOR: &str = "----------------------------------------";
 
+#[derive(Debug, Parser)]
+#[command(version, author, infer_long_args = true)]
+struct RawArgs {
+    /// Increase verbosity (-v for debug, -vv for trace; max useful: -vv)
+    #[arg(short = 'v', action = clap::ArgAction::Count)]
+    verbosity: u8,
+
+    /// Query remote services instead of using cached values.
+    #[arg(short = 'n', long)]
+    no_cache: bool,
+
+    /// Sync alerts to Google Calendar (requires GOOGLE_SERVICE_ACCOUNT_KEY and either GOOGLE_CALENDAR_ID or GOOGLE_CALENDAR_IDS env vars).
+    #[arg(short = 's', long)]
+    sync_calendar: bool,
+}
+
 #[derive(Debug)]
 struct Args {
     verbosity: Verbosity,
@@ -21,41 +37,12 @@ struct Args {
 }
 
 fn parse_args() -> Args {
-    let matches = Command::new("mbtalerts")
-        .version(env!("CARGO_PKG_VERSION"))
-        .author("Jacob Luszcz")
-        .infer_long_args(true)
-        .arg(
-            Arg::new("verbosity")
-                .short('v')
-                .action(ArgAction::Count)
-                .help("Increase verbosity (-v for debug, -vv for trace; max useful: -vv)"),
-        )
-        .arg(
-            Arg::new("no-cache")
-                .short('n')
-                .long("no-cache")
-                .action(ArgAction::SetTrue)
-                .help("Query remote services instead of using cached values."),
-        )
-        .arg(
-            Arg::new("sync-calendar")
-                .short('s')
-                .long("sync-calendar")
-                .action(ArgAction::SetTrue)
-                .help("Sync alerts to Google Calendar (requires GOOGLE_SERVICE_ACCOUNT_KEY and either GOOGLE_CALENDAR_ID or GOOGLE_CALENDAR_IDS env vars)."),
-        )
-        .get_matches();
-
-    let verbosity = matches.get_count("verbosity").into();
-
-    let cache_mode = !matches.get_flag("no-cache");
-    let sync_calendar = matches.get_flag("sync-calendar");
+    let raw = RawArgs::parse();
 
     Args {
-        verbosity,
-        cache_mode: cache_mode.into(),
-        sync_calendar,
+        verbosity: raw.verbosity.into(),
+        cache_mode: (!raw.no_cache).into(),
+        sync_calendar: raw.sync_calendar,
     }
 }
 


### PR DESCRIPTION
Replaces the Command/Arg builder in main.rs with a derive(Parser) RawArgs struct, mapped into the existing Args (which holds Verbosity/CacheMode rather than raw clap output).